### PR TITLE
Remove obsolete creds

### DIFF
--- a/bin/dse/install.sh
+++ b/bin/dse/install.sh
@@ -28,17 +28,7 @@ fi
 echo "Installing DataStax Enterprise"
 
 echo "Adding the DataStax repository"
-if [[ $cloud_type == "gce" ]] || [[ $cloud_type == "gke" ]]; then
-  echo "deb http://datastax%40google.com:8GdeeVT2s7zi@debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
-elif [[ $cloud_type == "azure" ]]; then
-  echo "deb http://datastax%40microsoft.com:3A7vadPHbNT@debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
-elif [[ $cloud_type == "aws" ]]; then
-  echo "deb http://datastax%40amazon.com:A8ePXn%5EHH0%260@debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
-elif [[ $cloud_type == "oracle" ]] || [[ $cloud_type == "bmc" ]]; then
-  echo "deb http://datastax%40oracle.com:*9En9HH4j%5Ep4@debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
-else
-  echo "deb http://datastax%40clouddev.com:CJ9o%21wOlDX1a@debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
-fi
+echo "deb https://debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
 
 # check for lock
 echo -e "Checking if apt/dpkg running, start: $(date +%r)"

--- a/bin/dse/install.sh
+++ b/bin/dse/install.sh
@@ -6,8 +6,8 @@ cloud_type=$1
 # Overidable by setting env var in calling template,
 # eg: export OPSC_VERSION='6.1.0'
 
-dse_version=5.1.9-1
-opscenter_version=6.5.0
+dse_version=5.1.19-1
+opscenter_version=6.7.8
 
 if [ -z "$OPSC_VERSION" ]
 then

--- a/bin/opscenter/install.sh
+++ b/bin/opscenter/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 cloud_type=$1
-opscenter_version=6.7.1
+opscenter_version=6.7.8
 
 if [ -z "$OPSC_VERSION" ]
 then

--- a/bin/opscenter/install.sh
+++ b/bin/opscenter/install.sh
@@ -13,17 +13,7 @@ fi
 echo "Installing OpsCenter"
 
 echo "Adding the DataStax repository"
-if [[ $cloud_type == "gce" ]] || [[ $cloud_type == "gke" ]]; then
-  echo "deb http://debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
-elif [[ $cloud_type == "azure" ]]; then
-  echo "deb http://debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
-elif [[ $cloud_type == "aws" ]]; then
-  echo "deb http://debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
-elif [[ $cloud_type == "oracle" ]] || [[ $cloud_type == "bmc" ]]; then
-  echo "deb http://debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
-else
-  echo "deb http://debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
-fi
+echo "deb https://debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
 
 echo -e "Checking if apt/dpkg running, start: $(date +%r)"
 while ps -A | grep -e apt -e dpkg >/dev/null 2>&1; do sleep 10s; done;


### PR DESCRIPTION
the repo has been accessible publically for a while now (and via https): https://debian.datastax.com/enterprise/

basic test for these changes was done on a ubuntu 16.04 vm by running these cmds successfully:
```
echo "deb https://debian.datastax.com/enterprise stable main" | sudo tee -a /etc/apt/sources.list.d/datastax.sources.list
curl -L http://debian.datastax.com/debian/repo_key | sudo apt-key add -
sudo apt-get update
export dse_version=5.1.17-1
sudo apt-get -y install dse-full=$dse_version dse=$dse_version dse-demos=$dse_version dse-libsolr=$dse_version dse-libtomcat=$dse_version dse-liblog4j=$dse_version dse-libcassandra=$dse_version dse-libspark=$dse_version dse-libhadoop2-client-native=$dse_version dse-libgraph=$dse_version dse-libhadoop2-client=$dse_version
export opscenter_version=6.7.5
sudo apt-get -y install datastax-agent=$opscenter_version
sudo apt-get -y install opscenter=$opscenter_version
```